### PR TITLE
Urlの#を復活

### DIFF
--- a/packages/client/lib/main.dart
+++ b/packages/client/lib/main.dart
@@ -4,7 +4,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 void main() {
-  usePathUrlStrategy();
   runApp(
     ProviderScope(child: App()),
   );


### PR DESCRIPTION
GitHub PagesだとSPAに対応できないみたいなので、一旦#を復活。FirebaseHostingに変える気になったら再度#を消す対応する。